### PR TITLE
Add support for webhook updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,24 @@ Or if you want to trigger an automation five minutes before the alarm will go of
       entity_id: light.bedroom
 ```
 
+## Webhook support
+HassAlarm supports updates through a webhook. This requires some setup on the Home Assistant side, but it greatly reduces the permissions the app has in Home Assistant.
+To use a webhook for HassAlarm updates, you can use the automation below and adapt it as necessary. Note that your webhook ID should be hard to guess.
+```yaml
+automation:
+  trigger:
+    platform: webhook
+    webhook_id: <your webhook id>
+  action:
+    service: input_datetime.set_datetime
+    data_template:
+      entity_id: "{{ trigger.json.entity_id }}"
+      datetime: "{{ trigger.json.datetime }}"
+```
 
 ## App usage
 1. Install via [Google Play Store](https://play.google.com/store/apps/details?id=com.fjun.hassalarm) or clone the repo and build the app: `./gradlew installDebug`
-1. Create a [long lived token](https://www.home-assistant.io/docs/authentication/#your-account-profile) on your profile in Home Assistant.
+1. Create a [long lived token](https://www.home-assistant.io/docs/authentication/#your-account-profile) on your profile or a webhook automation in Home Assistant.
 1. Open the app and setup your hostname, longed live token and input_datetime entity ID: `input_datetime.next_alarm`
 1. Schedule an alarm in any of your alarm apps
 

--- a/app/src/main/java/com/fjun/hassalarm/Constants.java
+++ b/app/src/main/java/com/fjun/hassalarm/Constants.java
@@ -10,6 +10,7 @@ interface Constants {
     String KEY_PREFS_HOST = "host";
     String KEY_PREFS_ENTITY_ID = "entity_id";
     String KEY_PREFS_IS_TOKEN = "is_token";
+    String KEY_PREFS_IS_WEBHOOK = "is_webhook";
     String KEY_PREFS_IS_ENTITY_ID_LEGACY = "is_entity_id_legacy";
     String DEFAULT_ENTITY_ID = "input_datetime.next_alarm";
     String DEFAULT_LEGACY_ENTITY_ID = "sensor.next_alarm";

--- a/app/src/main/java/com/fjun/hassalarm/EditConnectionActivity.java
+++ b/app/src/main/java/com/fjun/hassalarm/EditConnectionActivity.java
@@ -140,8 +140,8 @@ public class EditConnectionActivity extends AppCompatActivity {
                 !sharedPreferences.getString(KEY_PREFS_API_KEY, "").equals(mBinding.apiKeyInput.getText().toString().trim()) ||
                 !Migration.getEntityId(sharedPreferences).equals(mBinding.entityIdInput.getText().toString().trim()) ||
                 Migration.entityIdIsLegacy(sharedPreferences) != mBinding.isEntityLegacy.isChecked() ||
-                sharedPreferences.getBoolean(KEY_PREFS_IS_TOKEN, true) == mBinding.keyIsToken.isChecked() ||
-                sharedPreferences.getBoolean(KEY_PREFS_IS_WEBHOOK, true) == mBinding.keyIsWebhook.isChecked()) {
+                sharedPreferences.getBoolean(KEY_PREFS_IS_TOKEN, true) != mBinding.keyIsToken.isChecked() ||
+                sharedPreferences.getBoolean(KEY_PREFS_IS_WEBHOOK, false) != mBinding.keyIsWebhook.isChecked()) {
             new MaterialAlertDialogBuilder(this)
                     .setTitle(R.string.unsaved_changes_title)
                     .setMessage(R.string.unsaved_changes_message)

--- a/app/src/main/java/com/fjun/hassalarm/EditConnectionActivity.java
+++ b/app/src/main/java/com/fjun/hassalarm/EditConnectionActivity.java
@@ -36,6 +36,7 @@ import static com.fjun.hassalarm.Constants.KEY_PREFS_ENTITY_ID;
 import static com.fjun.hassalarm.Constants.KEY_PREFS_HOST;
 import static com.fjun.hassalarm.Constants.KEY_PREFS_IS_ENTITY_ID_LEGACY;
 import static com.fjun.hassalarm.Constants.KEY_PREFS_IS_TOKEN;
+import static com.fjun.hassalarm.Constants.KEY_PREFS_IS_WEBHOOK;
 import static com.fjun.hassalarm.Constants.PREFS_NAME;
 
 public class EditConnectionActivity extends AppCompatActivity {
@@ -66,7 +67,25 @@ public class EditConnectionActivity extends AppCompatActivity {
         final SharedPreferences sharedPreferences = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         mBinding.hostInput.setText(sharedPreferences.getString(KEY_PREFS_HOST, ""));
         mBinding.apiKeyInput.setText(sharedPreferences.getString(KEY_PREFS_API_KEY, ""));
-        mBinding.isApiInput.setChecked(!sharedPreferences.getBoolean(KEY_PREFS_IS_TOKEN, true));
+
+        mBinding.keyType.setOnCheckedChangeListener((group, checkedId) -> {
+            if (checkedId == mBinding.keyIsWebhook.getId()) {
+                mBinding.isEntityLegacy.setEnabled(false);
+            } else {
+                mBinding.isEntityLegacy.setEnabled(true);
+            }
+        });
+
+        int activeRadioButton;
+        if (sharedPreferences.getBoolean(KEY_PREFS_IS_TOKEN, true)) {
+            activeRadioButton = mBinding.keyIsToken.getId();
+        } else if (sharedPreferences.getBoolean(KEY_PREFS_IS_WEBHOOK, false)) {
+            activeRadioButton = mBinding.keyIsWebhook.getId();
+        } else {
+            activeRadioButton = mBinding.keyIsLegacy.getId();
+        }
+        mBinding.keyType.check(activeRadioButton);
+
 
         // Migration of old versions to new versions
         mBinding.entityIdInput.setText(Migration.getEntityId(sharedPreferences));
@@ -80,7 +99,8 @@ public class EditConnectionActivity extends AppCompatActivity {
                     .putString(KEY_PREFS_HOST, mBinding.hostInput.getText().toString().trim())
                     .putString(KEY_PREFS_API_KEY, mBinding.apiKeyInput.getText().toString().trim())
                     .putString(KEY_PREFS_ENTITY_ID, mBinding.entityIdInput.getText().toString().trim())
-                    .putBoolean(KEY_PREFS_IS_TOKEN, !mBinding.isApiInput.isChecked())
+                    .putBoolean(KEY_PREFS_IS_TOKEN, mBinding.keyIsToken.isChecked())
+                    .putBoolean(KEY_PREFS_IS_WEBHOOK, mBinding.keyIsWebhook.isChecked())
                     .putBoolean(KEY_PREFS_IS_ENTITY_ID_LEGACY, mBinding.isEntityLegacy.isChecked())
                     .putLong(Constants.LAST_PUBLISHED_TRIGGER_TIMESTAMP, 0)
                     .apply();
@@ -120,7 +140,8 @@ public class EditConnectionActivity extends AppCompatActivity {
                 !sharedPreferences.getString(KEY_PREFS_API_KEY, "").equals(mBinding.apiKeyInput.getText().toString().trim()) ||
                 !Migration.getEntityId(sharedPreferences).equals(mBinding.entityIdInput.getText().toString().trim()) ||
                 Migration.entityIdIsLegacy(sharedPreferences) != mBinding.isEntityLegacy.isChecked() ||
-                sharedPreferences.getBoolean(KEY_PREFS_IS_TOKEN, true) == mBinding.isApiInput.isChecked()) {
+                sharedPreferences.getBoolean(KEY_PREFS_IS_TOKEN, true) == mBinding.keyIsToken.isChecked() ||
+                sharedPreferences.getBoolean(KEY_PREFS_IS_WEBHOOK, true) == mBinding.keyIsWebhook.isChecked()) {
             new MaterialAlertDialogBuilder(this)
                     .setTitle(R.string.unsaved_changes_title)
                     .setMessage(R.string.unsaved_changes_message)
@@ -157,11 +178,20 @@ public class EditConnectionActivity extends AppCompatActivity {
         final String host = mBinding.hostInput.getText().toString().trim();
         final String token = mBinding.apiKeyInput.getText().toString().trim();
         final String entityId = mBinding.entityIdInput.getText().toString().trim();
-        final boolean isToken = !mBinding.isApiInput.isChecked();
+        final boolean isToken = mBinding.keyIsToken.isChecked();
+        final boolean isWebhook = mBinding.keyIsWebhook.isChecked();
         final boolean entityIdIsLegacy = mBinding.isEntityLegacy.isChecked();
 
-        mBinding.log.append((isToken ? getString(R.string.log_using_token) : getString(R.string.log_using_api_key)) + "\n");
-        mBinding.log.append((entityIdIsLegacy ? getString(R.string.log_entity_id_is_legacy_sensor) : getString(R.string.log_entity_id_is_input_datetime)) + "\n");
+        if (isToken) {
+            mBinding.log.append(getString(R.string.log_using_token) + "\n");
+        } else if (isWebhook) {
+            mBinding.log.append(getString(R.string.log_using_webhook) + "\n");
+        } else {
+            mBinding.log.append(getString(R.string.log_using_api_key) + "\n");
+        }
+        if (!isWebhook) {
+            mBinding.log.append((entityIdIsLegacy ? getString(R.string.log_entity_id_is_legacy_sensor) : getString(R.string.log_entity_id_is_input_datetime)) + "\n");
+        }
 
         try {
             mRequest = NextAlarmUpdaterJob.createRequest(this,
@@ -169,6 +199,7 @@ public class EditConnectionActivity extends AppCompatActivity {
                     token,
                     entityId,
                     isToken,
+                    isWebhook,
                     entityIdIsLegacy);
 
             final Call<ResponseBody> call = mRequest.call();

--- a/app/src/main/java/com/fjun/hassalarm/HassApi.java
+++ b/app/src/main/java/com/fjun/hassalarm/HassApi.java
@@ -4,6 +4,7 @@ import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.Header;
+import retrofit2.http.Headers;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
 
@@ -24,4 +25,8 @@ public interface HassApi {
 
     @POST("/api/services/input_datetime/set_datetime")
     Call<ResponseBody> setInputDatetimeUsingToken(@Body Datetime datetime, @Header("Authorization") String token);
+
+    @Headers("Content-type: application/json")
+    @POST("/api/webhook/{webhook_id}")
+    Call<ResponseBody> updateStateUsingWebhook(@Body Datetime datetime, @Path("webhook_id") String webhook_id);
 }

--- a/app/src/main/java/com/fjun/hassalarm/MainActivity.java
+++ b/app/src/main/java/com/fjun/hassalarm/MainActivity.java
@@ -6,6 +6,8 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -18,6 +20,7 @@ import com.fjun.hassalarm.databinding.ContentMainBinding;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.function.IntSupplier;
 
 import static com.fjun.hassalarm.Constants.PREFS_NAME;
 

--- a/app/src/main/res/layout/content_edit_connection.xml
+++ b/app/src/main/res/layout/content_edit_connection.xml
@@ -43,21 +43,63 @@
 
     </com.google.android.material.textfield.TextInputLayout>
 
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/is_api_input"
+    <RadioGroup
+        android:id="@+id/key_type"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/api_key"
         android:layout_marginBottom="10dp"
-        android:checked="false"
-        android:text="@string/is_legacy_api_key" />
+        android:checkedButton="@id/key_is_token">
+
+        <TextView
+            android:id="@+id/key_type_text"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:text="@string/key_type"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/key_type"
+            android:layout_marginBottom="10dp"
+            />
+
+        <RadioButton
+            android:id="@+id/key_is_token"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:text="@string/key_is_token"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/key_type_text"
+            android:layout_marginBottom="10dp"
+            />
+
+        <RadioButton
+            android:id="@+id/key_is_webhook"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:text="@string/key_is_webhook"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/key_is_token"
+            android:layout_marginBottom="10dp"
+            />
+
+        <RadioButton
+            android:id="@+id/key_is_legacy"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:text="@string/key_is_legacy"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/key_is_webhook"
+            android:layout_marginBottom="10dp"
+            />
+
+    </RadioGroup>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/entity_id"
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/is_api_input"
+        android:layout_below="@id/key_type"
         android:layout_marginBottom="10dp">
 
         <com.google.android.material.textfield.TextInputEditText

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,11 +2,15 @@
     <string name="app_name">Hassalarm</string>
     <string name="no_scheduled_alarm">No next alarm scheduled.</string>
     <string name="hass_io_host_name_ip">Home Assistant host name/IP</string>
-    <string name="hass_io_api_key">Home Assistant long lived token or legacy API key</string>
+    <string name="hass_io_api_key">Home Assistant access key</string>
     <string name="next_alarm">Next scheduled alarm %s</string>
     <string name="toast_saved">Connection details saved.</string>
     <string name="hass_io_entity_id">Entity ID</string>
-    <string name="is_legacy_api_key">Above value is legacy API key instead of long lived token</string>
+    <string name="key_type">Access type</string>
+    <string name="key_is_token">Long-lived access token</string>
+    <string name="key_is_webhook">Webhook ID</string>
+    <string name="key_is_legacy">API password (deprecated)</string>
+    <string name="button_close">Close</string>
     <string name="status_running">Running connection test…</string>
     <string name="status_done_ok">Connection successful.</string>
     <string name="status_done_failed">Connection failed, see log.</string>
@@ -39,6 +43,7 @@
     <string name="copy_full_log">Copy full log</string>
     <string name="copy_anonymous_log">Copy anonymous log</string>
     <string name="log_using_token">Using long lived token</string>
+    <string name="log_using_webhook">Using webhook ID</string>
     <string name="log_using_api_key">Using legacy API key</string>
     <string name="log_entity_id_is_legacy_sensor">Entity ID is of type legacy sensor</string>
     <string name="log_entity_id_is_input_datetime">Entity ID is of type input_datetime</string>


### PR DESCRIPTION
As the title says, we can use webhooks to push our updates.
This will avoid the need for an all-access long-lived token.