### PR TITLE
Add Signal App to list of queries

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         <package android:name="com.miui.screenrecorder" />
         <package android:name="com.huawei.parentcontrol" />
         <package android:name="com.coloros.safekid" />
+        <package android:name="org.thoughtcrime.securesms" />
     </queries>
 
     <application


### PR DESCRIPTION
`android:name` taken from https://github.com/signalapp/Signal-Android/commit/08254edae68893a8112bbfff5dbc216a0c576ab2 but I removed `.benchmark`, which should be correct.

Related to https://github.com/Johboh/hassalarm/issues/30 but not closing that issue.